### PR TITLE
Add support for "labeled" footnotes

### DIFF
--- a/ox-html-markdown-style-footnotes.el
+++ b/ox-html-markdown-style-footnotes.el
@@ -37,12 +37,12 @@
            (mapconcat
             (lambda (definition)
               (pcase definition
-                (`(,n ,_ ,def)
+                (`(,n ,label ,def)
                  (format
-                  "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
-                  n
+                  "<li id=\"fn.%s\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
+                  (or label n)
                   (org-trim (org-export-data def info))
-                  (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
+                  (format "<a href=\"#fnr.%s\" role=\"doc-backlink\">↩&#65038;</a>" (or label n))))))
             definitions
             "\n")))))
     (funcall orig-fun info)))

--- a/ox-html-markdown-style-footnotes.el
+++ b/ox-html-markdown-style-footnotes.el
@@ -27,24 +27,24 @@
 (defun org-html-markdown-style-footnotes--section (orig-fun info)
   (if org-html-markdown-style-footnotes
       (pcase (org-export-collect-footnote-definitions info)
-	(`nil nil)
-	(definitions
-	 (format
-	  (plist-get info :html-footnotes-section)
-	  (org-html--translate "Footnotes" info)
-	  (format
-	   "<ol>\n%s</ol>\n"
-	   (mapconcat
-	    (lambda (definition)
-	      (pcase definition
-		(`(,n ,_ ,def)
-		 (format
-		  "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
+        (`nil nil)
+        (definitions
+         (format
+          (plist-get info :html-footnotes-section)
+          (org-html--translate "Footnotes" info)
+          (format
+           "<ol>\n%s</ol>\n"
+           (mapconcat
+            (lambda (definition)
+              (pcase definition
+                (`(,n ,_ ,def)
+                 (format
+                  "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
                   n
-		  (org-trim (org-export-data def info))
-		  (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
-	    definitions
-	    "\n")))))
+                  (org-trim (org-export-data def info))
+                  (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
+            definitions
+            "\n")))))
     (funcall orig-fun info)))
 
   ;;;###autoload

--- a/ox-html-markdown-style-footnotes.org
+++ b/ox-html-markdown-style-footnotes.org
@@ -235,25 +235,25 @@ The updated copy is defined as ~org-html-markdown-style-footnotes--section~:
 #+begin_src emacs-lisp
   (defun org-html-markdown-style-footnotes--section (orig-fun info)
     (if org-html-markdown-style-footnotes
-	(pcase (org-export-collect-footnote-definitions info)
-	  (`nil nil)
-	  (definitions
-	   (format
-	    (plist-get info :html-footnotes-section)
-	    (org-html--translate "Footnotes" info)
-	    (format
-	     "<ol>\n%s</ol>\n"
-	     (mapconcat
-	      (lambda (definition)
-		(pcase definition
-		  (`(,n ,_ ,def)
-		   (format
-		    "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
+        (pcase (org-export-collect-footnote-definitions info)
+          (`nil nil)
+          (definitions
+           (format
+            (plist-get info :html-footnotes-section)
+            (org-html--translate "Footnotes" info)
+            (format
+             "<ol>\n%s</ol>\n"
+             (mapconcat
+              (lambda (definition)
+                (pcase definition
+                  (`(,n ,_ ,def)
+                   (format
+                    "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
                     n
-		    (org-trim (org-export-data def info))
-		    (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
-	      definitions
-	      "\n")))))
+                    (org-trim (org-export-data def info))
+                    (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
+              definitions
+              "\n")))))
       (funcall orig-fun info)))
 #+end_src
 

--- a/ox-html-markdown-style-footnotes.org
+++ b/ox-html-markdown-style-footnotes.org
@@ -246,12 +246,12 @@ The updated copy is defined as ~org-html-markdown-style-footnotes--section~:
              (mapconcat
               (lambda (definition)
                 (pcase definition
-                  (`(,n ,_ ,def)
+                  (`(,n ,label ,def)
                    (format
-                    "<li id=\"fn.%d\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
-                    n
+                    "<li id=\"fn.%s\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">%s %s</li>\n"
+                    (or label n)
                     (org-trim (org-export-data def info))
-                    (format "<a href=\"#fnr.%d\" role=\"doc-backlink\">↩&#65038;</a>" n)))))
+                    (format "<a href=\"#fnr.%s\" role=\"doc-backlink\">↩&#65038;</a>" (or label n))))))
               definitions
               "\n")))))
       (funcall orig-fun info)))

--- a/ox-html-markdown-style-footnotes.org
+++ b/ox-html-markdown-style-footnotes.org
@@ -109,7 +109,7 @@ This results in footnotes with support for multiple paragraphs, that work withou
 
 * Implementation
 
-In [[https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/ox-html.el?h=release_9.6.5#n1858][Org mode 9.6.5]], the ~org-html-footnote-section~ looks like this:
+In [[https://cgit.git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/ox-html.el?h=release_9.7.34#n1870][Org mode 9.7.34]] the ~org-html-footnote-section~ looks like this:
 
 #+headers: :noweb yes
 #+begin_src emacs-lisp
@@ -127,7 +127,7 @@ In [[https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/ox-html.el?h
          (mapconcat
           (lambda (definition)
             (pcase definition
-              (`(,n ,_ ,def)
+              (`(,n ,label ,def)
                <<footnote-definitions>>)))
           definitions
           "\n"))))))
@@ -138,12 +138,24 @@ The interesting part is executed for each footnote, and wraps each footnote in a
 
 #+name: footnote-definitions
 #+begin_src emacs-lisp
+  ;; Do not assign number labels as they appear in Org mode
+  ;; - the footnotes are re-numbered by
+  ;; `org-export-get-footnote-number'.  If the label is not
+  ;; a number, keep it.
+  (when (and (stringp label)
+             (equal label (number-to-string (string-to-number label))))
+    (setq label nil))
+  ;; `org-export-collect-footnote-definitions' can return
+  ;; two kinds of footnote definitions: inline and blocks.
+  ;; Since this should not make any difference in the HTML
+  ;; output, we wrap the inline definitions within
+  ;; a "footpara" class paragraph.
   (let ((inline? (not (org-element-map def org-element-all-elements
                         #'identity nil t)))
         (anchor (org-html--anchor
-                 (format "fn.%d" n)
+                 (format "fn.%s" (or label n))
                  n
-                 (format " class=\"footnum\" href=\"#fnr.%d\" role=\"doc-backlink\"" n)
+                 (format " class=\"footnum\" href=\"#fnr.%s\" role=\"doc-backlink\"" (or label n))
                  info))
         (contents (org-trim (org-export-data def info))))
     (format "<div class=\"footdef\">%s %s</div>\n"

--- a/test.el
+++ b/test.el
@@ -11,6 +11,16 @@
 	   (with-current-buffer "*Org HTML Export*" (buffer-string))))
   (org-html-markdown-style-footnotes-remove))
 
+(ert-deftest labeled-footnote-test ()
+  (org-html-markdown-style-footnotes-add)
+  (find-file "test/fixtures/labeled-footnote.org")
+  (let ((org-html-markdown-style-footnotes t))
+    (org-html-export-as-html))
+  (should (string-match-p
+	   "<ol>\n<li id=\"fn.labeled\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\"><p class=\"footpara\">\nA footnote.\n</p>\n\n<p class=\"footpara\">\nWith a second paragraph.\n</p> <a href=\"#fnr.labeled\" role=\"doc-backlink\">↩&#65038;</a></li>\n</ol>"
+	   (with-current-buffer "*Org HTML Export*" (buffer-string))))
+  (org-html-markdown-style-footnotes-remove))
+
 (ert-deftest disabled-test ()
   (org-html-markdown-style-footnotes-add)
   (find-file "test/fixtures/footnote.org")

--- a/test/fixtures/labeled-footnote.org
+++ b/test/fixtures/labeled-footnote.org
@@ -1,0 +1,5 @@
+Hello, world![fn:labeled]
+
+[fn:labeled] A footnote.
+
+With a second paragraph.


### PR DESCRIPTION
Newer versions of Org<sup><a id="fnr.target" class="footref" href="#fn.target" role="doc-backlink">1</a></sup> uses footnote labels as their anchors.

```org
Hello, world![fn:labeled]

[fn:labeled] A footnote.
```

In previous versions, the example above would produce a footnote with `fn.1` as the anchor:

```html
<ol>
  <li id=\"fn.1\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">
    <p class=\"footpara\">A footnote.</p>
    <p class=\"footpara\">\nWith a second paragraph.\n</p>
    <a href=\"#fnr.1\" role=\"doc-backlink\">↩&#65038;</a>
  </li>
</ol>
```

This produced broken links, as Org now uses `fn.labeled` when linking to this footnote from the footnote reference.

This patch uses the label if available and falls back to numbered foonotes. The example above now produces a "labeled" footnote:

```html
<ol>
  <li id=\"fn.labeled\" class=\"footdef\" role=\"doc-footnote\" tabindex=\"-1\">
    <p class=\"footpara\">A footnote.</p>
    <p class=\"footpara\">\nWith a second paragraph.\n</p>
    <a href=\"#fnr.labeled\" role=\"doc-backlink\">↩&#65038;</a>
  </li>
</ol>
```

<sup><a id="fn.1" class="footnum" href="#fnr.1">1</a></sup> ox-html-markdown-style-footnotes now targets Emacs 30.2, which bundles with Org 9.7.13.
